### PR TITLE
Fix /greed command not rolling on items that can be Needed and added small random variable delay to make automation detection less trivial

### DIFF
--- a/LazyLoot/Plugin/Plugin.cs
+++ b/LazyLoot/Plugin/Plugin.cs
@@ -204,7 +204,7 @@ namespace LazyLoot.Plugin
             int num = 0;
             for (int index = 0; index < LootItems.Count; ++index)
             {
-                if (LootItems[index].RollState == RollState.UpToGreed)
+                if (LootItems[index].RollState <= RollState.UpToGreed)
                 {
                     await RollItemAsync(RollOption.Greed, index);
                     ++num;
@@ -369,7 +369,7 @@ namespace LazyLoot.Plugin
         {
             if (Plugin.config.EnableRollDelay)
             {
-                await Task.Delay(new TimeSpan(0, 0, Plugin.config.RollDelayInSeconds));
+                await Task.Delay(new TimeSpan(0, 0, 0, Plugin.config.RollDelayInSeconds, new Random().Next(-250, 251)));
             }
 
             LootItem lootItem = LootItems[index];


### PR DESCRIPTION
/greed will now roll Greed on all possible items (as seems to be intended by the description), even if they could potentially be rolled Need.. A random variable delay of +/-250ms has been added to the configured constant delay between rolls as currently rolls will be at _exact_ intervals down to the millisecond and are very easily detectable as automation..