### PR TITLE
[FULF] Allows customization of initial FULF rolling delay

### DIFF
--- a/LazyLoot/Commands/RollCommand.cs
+++ b/LazyLoot/Commands/RollCommand.cs
@@ -56,7 +56,7 @@ namespace LazyLoot.Commands
 
             if (Plugin.LazyLoot.FulfEnabled)
             {
-                await Task.Delay(new Random().Next(1000, 3001));
+                await Task.Delay(new Random().Next((int)Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds * 1000, (int)Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds * 1000));
             }
 
             int itemsNeed = 0;

--- a/LazyLoot/Config/Configuration.cs
+++ b/LazyLoot/Config/Configuration.cs
@@ -12,17 +12,19 @@ namespace LazyLoot.Config
         public bool EnableErrorToast = false;
         public bool EnableNormalToast = false;
         public bool EnableQuestToast = true;
-        
+
         // FulfRollOption
         public bool EnableGreedRoll = false;
         public bool EnableNeedOnlyRoll = false;
         public bool EnableNeedRoll = true;
         public bool EnablePassRoll = false;
-        
+
         // RollDelay
         public bool EnableRollDelay = true;
         public float MinRollDelayInSeconds = 0.5f;
         public float MaxRollDelayInSeconds = 1f;
+        public float FulfInitialRollDelayInSeconds = 1.5f;
+        public float FulfFinalRollDelayInSeconds = 3f;
 
         // Restrictions
         // ILvl

--- a/LazyLoot/Ui/ConfigUi.cs
+++ b/LazyLoot/Ui/ConfigUi.cs
@@ -14,7 +14,7 @@ namespace LazyLoot.Ui
         internal WindowSystem windowSystem = new();
         private string? toastPreview;
 
-        public ConfigUi() : base("Lazy Loot Config" )
+        public ConfigUi() : base("Lazy Loot Config")
         {
             SizeConstraints = new WindowSizeConstraints()
             {
@@ -145,7 +145,7 @@ namespace LazyLoot.Ui
                 }
             }
 
-            ImGui.TextColored( ImGuiColors.DalamudRed, "Ignore items even if they are tradeable, do you want to trade them, don't ignore them.");
+            ImGui.TextColored(ImGuiColors.DalamudRed, "Ignore items even if they are tradeable, do you want to trade them, don't ignore them.");
             ImGui.Checkbox("Ignore all items already unlocked. ( Cards, Music, Faded copy, Minions, Mounts, Emotes, Hairstyle )", ref Plugin.LazyLoot.config.RestrictionIgnoreItemUnlocked);
             ImGui.Checkbox("Ignore unlocked mounts.", ref Plugin.LazyLoot.config.RestrictionIgnoreMounts);
             ImGui.Checkbox("Ignore unlocked minions.", ref Plugin.LazyLoot.config.RestrictionIgnoreMinions);
@@ -293,6 +293,26 @@ namespace LazyLoot.Ui
                 }
 
                 ImGui.EndCombo();
+            }
+
+            ImGui.Text("First Roll Delay Range (In seconds)");
+
+            ImGui.SetNextItemWidth(100);
+            ImGui.DragFloat(" ", ref Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds, 1.5f);
+
+            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds < 1.5f)
+            {
+                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = 1.5f;
+            }
+            ImGui.SameLine();
+            ImGui.Text("to ");
+            ImGui.SameLine();
+            ImGui.SetNextItemWidth(100);
+            ImGui.DragFloat("  ", ref Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds, Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds + 1.5f);
+
+            if (Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds < Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds + 1.5f)
+            {
+                Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds = Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds + 1.5f;
             }
         }
     }

--- a/LazyLoot/Ui/ConfigUi.cs
+++ b/LazyLoot/Ui/ConfigUi.cs
@@ -305,9 +305,9 @@ namespace LazyLoot.Ui
                 Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds - 0.1f;
             }
 
-            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds < 0.1f)
+            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds < 1.5f)
             {
-                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = 0.1f;
+                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = 1.5f;
             }
 
             ImGui.SetNextItemWidth(100);

--- a/LazyLoot/Ui/ConfigUi.cs
+++ b/LazyLoot/Ui/ConfigUi.cs
@@ -102,7 +102,7 @@ namespace LazyLoot.Ui
                 ImGui.SetNextItemWidth(100);
                 ImGui.DragFloat("Min in seconds.", ref Plugin.LazyLoot.config.MinRollDelayInSeconds, 0.1F);
 
-        
+
                 if (Plugin.LazyLoot.config.MinRollDelayInSeconds >= Plugin.LazyLoot.config.MaxRollDelayInSeconds)
                 {
                     Plugin.LazyLoot.config.MinRollDelayInSeconds = Plugin.LazyLoot.config.MaxRollDelayInSeconds - 0.1f;
@@ -296,24 +296,34 @@ namespace LazyLoot.Ui
             }
 
             ImGui.Text("First Roll Delay Range (In seconds)");
+            ImGui.SetNextItemWidth(100);
+            ImGui.DragFloat("Min in seconds. ", ref Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds, 0.1F);
+
+
+            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds >= Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds)
+            {
+                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds - 0.1f;
+            }
+
+            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds < 0.1f)
+            {
+                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = 0.1f;
+            }
 
             ImGui.SetNextItemWidth(100);
-            ImGui.DragFloat(" ", ref Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds, 1.5f);
+            ImGui.DragFloat("Max in seconds. ", ref Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds, 0.1F);
 
-            if (Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds < 1.5f)
+            if (Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds <= Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds)
             {
-                Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds = 1.5f;
+                Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds = Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds + 0.1f;
             }
-            ImGui.SameLine();
-            ImGui.Text("to ");
-            ImGui.SameLine();
-            ImGui.SetNextItemWidth(100);
-            ImGui.DragFloat("  ", ref Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds, Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds + 1.5f);
 
-            if (Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds < Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds + 1.5f)
+            if (Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds < 0.1f)
             {
-                Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds = Plugin.LazyLoot.config.FulfInitialRollDelayInSeconds + 1.5f;
+                Plugin.LazyLoot.config.FulfFinalRollDelayInSeconds = 0.1f;
             }
+            ImGui.Separator();
+
         }
     }
 }


### PR DESCRIPTION
Adds a new configuration to allow the user to customize their FULF initial rolling delay, with a minimum of 1.5 seconds.
Defaults to 1.5 seconds minimum and 3 seconds maximum.
Follows the same rule for the rolling delay.

![image](https://user-images.githubusercontent.com/19570528/222421373-5ebd3d4b-1803-440a-b24d-3849d89db174.png)